### PR TITLE
Fizzbuzz april 9 v1

### DIFF
--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
@@ -1,3 +1,3 @@
 export function fizzbuzz(n: number) {
-  return "";
+  return "fizz";
 }

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
@@ -1,4 +1,7 @@
 export function fizzbuzz(n: number) {
+  if (n % 3 === 0 && n % 5 === 0) {
+    return "fizzbuzz";
+  }
   if (n === 5) return "buzz";
   return "fizz";
 }

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
@@ -3,5 +3,6 @@ export function fizzbuzz(n: number) {
     return "fizzbuzz";
   }
   if (n === 5) return "buzz";
-  return "fizz";
+  if (n === 3) return "fizz";
+  return String(n);
 }

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
@@ -2,7 +2,7 @@ export function fizzbuzz(n: number) {
   if (n % 3 === 0 && n % 5 === 0) {
     return "fizzbuzz";
   }
-  if (n === 5) return "buzz";
+  if (n % 5 === 0) return "buzz";
   if (n % 3 === 0) return "fizz";
   return String(n);
 }

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
@@ -1,3 +1,4 @@
 export function fizzbuzz(n: number) {
+  if (n === 5) return "buzz";
   return "fizz";
 }

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
@@ -1,1 +1,3 @@
-export function fizzbuzz() {}
+export function fizzbuzz(n: number) {
+  return "";
+}

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
@@ -1,0 +1,1 @@
+export function fizzbuzz() {}

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
@@ -1,4 +1,7 @@
 export function fizzbuzz(n: number) {
+  if (n > 100) {
+    throw new Error("n must be less than 101");
+  }
   if (n % 3 === 0 && n % 5 === 0) {
     return "fizzbuzz";
   }

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
@@ -3,6 +3,6 @@ export function fizzbuzz(n: number) {
     return "fizzbuzz";
   }
   if (n === 5) return "buzz";
-  if (n === 3) return "fizz";
+  if (n % 3 === 0) return "fizz";
   return String(n);
 }

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/fizzbuzz.ts
@@ -2,6 +2,11 @@ export function fizzbuzz(n: number) {
   if (n > 100) {
     throw new Error("n must be less than 101");
   }
+
+  if (n < 1) {
+    throw new Error("n must be bigger than 0");
+  }
+
   if (n % 3 === 0 && n % 5 === 0) {
     return "fizzbuzz";
   }

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -24,4 +24,8 @@ describe("fizzbuzz", () => {
   it("should return '43' if i pass the number 43", () => {
     expect(fizzbuzz(43)).toBe("43");
   });
+
+  it("should return 'fizz' when i pass the number 9", () => {
+    expect(fizzbuzz(9)).toBe("fizz");
+  });
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -4,4 +4,8 @@ describe("fizzbuzz", () => {
   it("should exist", () => {
     expect(fizzbuzz).toBeDefined();
   });
+
+  it("should return a string", () => {
+    expect(typeof fizzbuzz(1)).toBe("string");
+  });
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -20,4 +20,8 @@ describe("fizzbuzz", () => {
   it("should return 'fizzbuzz' if I pass the number 15", () => {
     expect(fizzbuzz(15)).toBe("fizzbuzz");
   });
+
+  it("should return '43' if i pass the number 43", () => {
+    expect(fizzbuzz(43)).toBe("43");
+  });
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -1,3 +1,5 @@
+import { fizzbuzz } from "./fizzbuzz";
+
 describe("fizzbuzz", () => {
   it("should exist", () => {
     expect(fizzbuzz).toBeDefined();

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -36,4 +36,8 @@ describe("fizzbuzz", () => {
   it("should throw an error when i pass the number 102", () => {
     expect(() => fizzbuzz(102)).toThrow(new Error("n must be less than 101"));
   });
+
+  it("should throw an error when i pass the number -12", () => {
+    expect(() => fizzbuzz(-12)).toThrow(new Error("n must be bigger than 1"));
+  });
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -38,6 +38,6 @@ describe("fizzbuzz", () => {
   });
 
   it("should throw an error when i pass the number -12", () => {
-    expect(() => fizzbuzz(-12)).toThrow(new Error("n must be bigger than 1"));
+    expect(() => fizzbuzz(-12)).toThrow(new Error("n must be bigger than 0"));
   });
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -9,8 +9,8 @@ describe("fizzbuzz", () => {
     expect(typeof fizzbuzz(1)).toBe("string");
   });
 
-  it("should return 'fizz' if I pass the number 3", () => {
-    expect(fizzbuzz(3)).toBe("fizz");
+  it.each([3, 9, 42])("should return 'fizz' if I pass the number %i", (n) => {
+    expect(fizzbuzz(n)).toBe("fizz");
   });
 
   it("should return 'buzz' if I pass the number 5", () => {
@@ -25,10 +25,6 @@ describe("fizzbuzz", () => {
     expect(fizzbuzz(43)).toBe("43");
   });
 
-  it("should return 'fizz' when i pass the number 9", () => {
-    expect(fizzbuzz(9)).toBe("fizz");
-  });
-
   it("should return 'buzz' when i pass the number 10", () => {
     expect(fizzbuzz(10)).toBe("buzz");
   });
@@ -39,10 +35,6 @@ describe("fizzbuzz", () => {
 
   it("should throw an error when i pass the number -12", () => {
     expect(() => fizzbuzz(-12)).toThrow(new Error("n must be bigger than 0"));
-  });
-
-  it("should return 'fizz' when i pass the number 42", () => {
-    expect(fizzbuzz(42)).toBe("fizz");
   });
 
   it("should return 'fizzbuzz' if I pass the number 45", () => {

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -12,4 +12,8 @@ describe("fizzbuzz", () => {
   it("should return 'fizz' if I pass the number 3", () => {
     expect(fizzbuzz(3)).toBe("fizz");
   });
+
+  it("should return 'buzz' if I pass the number 5", () => {
+    expect(fizzbuzz(5)).toBe("buzz");
+  });
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -28,4 +28,8 @@ describe("fizzbuzz", () => {
   it("should return 'fizz' when i pass the number 9", () => {
     expect(fizzbuzz(9)).toBe("fizz");
   });
+
+  it("should return 'buzz' when i pass the number 10", () => {
+    expect(fizzbuzz(10)).toBe("buzz");
+  });
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -32,4 +32,8 @@ describe("fizzbuzz", () => {
   it("should return 'buzz' when i pass the number 10", () => {
     expect(fizzbuzz(10)).toBe("buzz");
   });
+
+  it("should throw an error when i pass the number 102", () => {
+    expect(() => fizzbuzz(102)).toThrow(new Error("n must be less than 101"));
+  });
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -8,4 +8,8 @@ describe("fizzbuzz", () => {
   it("should return a string", () => {
     expect(typeof fizzbuzz(1)).toBe("string");
   });
+
+  it("should return 'fizz' if I pass the number 3", () => {
+    expect(fizzbuzz(3)).toBe("fizz");
+  });
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -44,4 +44,8 @@ describe("fizzbuzz", () => {
   it("should return 'fizz' when i pass the number 42", () => {
     expect(fizzbuzz(42)).toBe("fizz");
   });
+
+  it("should return 'fizzbuzz' if I pass the number 45", () => {
+    expect(fizzbuzz(45)).toBe("fizzbuzz");
+  });
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -40,4 +40,8 @@ describe("fizzbuzz", () => {
   it("should throw an error when i pass the number -12", () => {
     expect(() => fizzbuzz(-12)).toThrow(new Error("n must be bigger than 0"));
   });
+
+  it("should return 'fizz' when i pass the number 42", () => {
+    expect(fizzbuzz(42)).toBe("fizz");
+  });
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -17,7 +17,7 @@ describe("fizzbuzz", () => {
     expect(fizzbuzz(5)).toBe("buzz");
   });
 
-  it("should return 'fizzbuzz' if I pass the number 5", () => {
+  it("should return 'fizzbuzz' if I pass the number 15", () => {
     expect(fizzbuzz(15)).toBe("fizzbuzz");
   });
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -1,5 +1,5 @@
-
 describe("fizzbuzz", () => {
-
-
+  it("should exist", () => {
+    expect(fizzbuzz).toBeDefined();
+  });
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_1_Fizzbuzz/src/index.spec.ts
@@ -16,4 +16,8 @@ describe("fizzbuzz", () => {
   it("should return 'buzz' if I pass the number 5", () => {
     expect(fizzbuzz(5)).toBe("buzz");
   });
+
+  it("should return 'fizzbuzz' if I pass the number 5", () => {
+    expect(fizzbuzz(15)).toBe("fizzbuzz");
+  });
 });


### PR DESCRIPTION
I have committed on every single transition from red to green to refactor
- [x] I have tests that validate the following statements
each return value is a string 
3 returns "Fizz"
5 returns "Buzz
15 returns "FizzBuzz"
9 returns "Fizz"
43 returns "43"
42 returns "Fizz"
45 returns "FizzBuzz"
102 (you decide, throw an Error or handle some other way)
-12 (you decide, throw an Error or handle some other way)
any non-number (you decide, throw an Error or handle some other way)

- [x] Once I have made the aforementioned tests pass, I have refactored my test specifications to use it.each() to perform parameterization ([see Tip #3 here](https://www.essentialist.dev/products/the-software-essentialist/categories/2152752280/posts/2166919573))
- [x]  There is no duplication in my test code or my production code