### PR TITLE
Military time validator 30 april v2

### DIFF
--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/UPFRONT.md
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/UPFRONT.md
@@ -1,0 +1,27 @@
+Responsibilities:
+- Should know if a time range is correct:
+    - 1:12 - 12:32
+    - 12:32 - 17:18
+    - 00:33 - 8:12
+
+- Should know if a time range have incorrect format:
+    - 1:12-12:32
+    - 1:1212:32
+    - 12:32 ~ 17:18
+    - 00:33 - 8:12 - 13:12
+
+- Should know if a military time have incorrect format:
+    - 1.12 - 12:32
+    - 12:32 - 17.18
+    - 0033 - 8:12
+    - 00:33 - 812
+
+- Should know if a military time hour or minute is out of range:
+    - 27:32 - 12:45
+    - 12:77 - 16:56
+    - 12:45 - 27:23
+    - 22:45 - 23:87
+    - -12:33 - 14:32
+    - 12:-33 - 14:32
+    - 12:33 - -14:32
+    - 12:33 - 14:-32

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -24,6 +24,10 @@ describe("military time validator", () => {
         const valid = MilitaryTimeValidator.validate("1.12 - 12:32");
         expect(valid).toBeFalsy();
       });
+      it("Should know that the military time 1:12 - 12.32 is not valid", () => {
+        const valid = MilitaryTimeValidator.validate("1:12 - 12.32");
+        expect(valid).toBeFalsy();
+      });
     });
   });
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -6,5 +6,12 @@ describe("military time validator", () => {
       const valid = MilitaryTimeValidator.validate("12:33 - 15:52");
       expect(valid).toBeTruthy();
     });
+
+    describe("Should know if a time range have incorrect format", () => {
+      it("Should know that the time range 1:12-12:32 is not valid", () => {
+        const valid = MilitaryTimeValidator.validate("1:12-12:32");
+        expect(valid).toBeFalsy();
+      });
+    });
   });
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -39,6 +39,10 @@ describe("military time validator", () => {
         const valid = MilitaryTimeValidator.validate("22:123 - 12:54");
         expect(valid).toBeFalsy();
       });
+      it("Should know that the time range 22.23:12 - 12:45 is not valid", () => {
+        const valid = MilitaryTimeValidator.validate("22.23:12 - 12:54");
+        expect(valid).toBeFalsy();
+      });
     });
   });
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -51,6 +51,10 @@ describe("military time validator", () => {
         const valid = MilitaryTimeValidator.validate("2I:12 - 12:54");
         expect(valid).toBeFalsy();
       });
+      it("Should know that the time range 20:2P - 12:45 is not valid", () => {
+        const valid = MilitaryTimeValidator.validate("20:2P - 12:54");
+        expect(valid).toBeFalsy();
+      });
     });
   });
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -43,6 +43,10 @@ describe("military time validator", () => {
         const valid = MilitaryTimeValidator.validate("22.23:12 - 12:54");
         expect(valid).toBeFalsy();
       });
+      it("Should know that the time range 22:12.11 - 12:45 is not valid", () => {
+        const valid = MilitaryTimeValidator.validate("22:12.11 - 12:54");
+        expect(valid).toBeFalsy();
+      });
     });
   });
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -12,6 +12,11 @@ describe("military time validator", () => {
         const valid = MilitaryTimeValidator.validate("1:12-12:32");
         expect(valid).toBeFalsy();
       });
+
+      it("Should know that the time range 1:12 - 12:32 - 14:44 is not valid", () => {
+        const valid = MilitaryTimeValidator.validate("1:12 - 12:32 - 14:44");
+        expect(valid).toBeFalsy();
+      });
     });
   });
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -18,5 +18,12 @@ describe("military time validator", () => {
         expect(valid).toBeFalsy();
       });
     });
+
+    describe("Should know if a military time have incorrect format", () => {
+      it("Should know that the military time 1.12 - 12:32 is not valid", () => {
+        const valid = MilitaryTimeValidator.validate("1.12 - 12:32");
+        expect(valid).toBeFalsy();
+      });
+    });
   });
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -35,6 +35,10 @@ describe("military time validator", () => {
         const valid = MilitaryTimeValidator.validate("27:32 - 12:54");
         expect(valid).toBeFalsy();
       });
+      it("Should know that the time range 22:123 - 12:45 is not valid", () => {
+        const valid = MilitaryTimeValidator.validate("22:123 - 12:54");
+        expect(valid).toBeFalsy();
+      });
     });
   });
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -2,59 +2,44 @@ import { MilitaryTimeRangeValidator } from "./index";
 
 describe("military time validator", () => {
   describe("Should know if a time range is correct", () => {
-    it("Should know that the time range 12:33 - 15:52 is valid", () => {
-      const valid = MilitaryTimeRangeValidator.validate("12:33 - 15:52");
-      expect(valid).toBeTruthy();
-    });
+    it.each(["12:33 - 15:52", "23:32 - 23:56", "1:22 - 12:33", "00:33 - 9:22"])(
+      "Should know that the time range %s is valid",
+      (timeRange) => {
+        const valid = MilitaryTimeRangeValidator.validate(timeRange);
+        expect(valid).toBeTruthy();
+      }
+    );
 
     describe("Should know if a time range have incorrect format", () => {
-      it("Should know that the time range 1:12-12:32 is not valid", () => {
-        const valid = MilitaryTimeRangeValidator.validate("1:12-12:32");
-        expect(valid).toBeFalsy();
-      });
-
-      it("Should know that the time range 1:12 - 12:32 - 14:44 is not valid", () => {
-        const valid = MilitaryTimeRangeValidator.validate(
-          "1:12 - 12:32 - 14:44"
-        );
-        expect(valid).toBeFalsy();
-      });
+      it.each(["1:12-12:32", "1:12 - 12:33 - 14:44", "22:33 ~ 23:10"])(
+        "Should know that the time range %s is not valid",
+        (timeRange) => {
+          const valid = MilitaryTimeRangeValidator.validate(timeRange);
+          expect(valid).toBeFalsy();
+        }
+      );
     });
 
     describe("Should know if a military time have incorrect format", () => {
-      it("Should know that the military time 1.12 - 12:32 is not valid", () => {
-        const valid = MilitaryTimeRangeValidator.validate("1.12 - 12:32");
-        expect(valid).toBeFalsy();
-      });
-      it("Should know that the military time 1:12 - 12.32 is not valid", () => {
-        const valid = MilitaryTimeRangeValidator.validate("1:12 - 12.32");
-        expect(valid).toBeFalsy();
-      });
+      it.each(["1.12 - 12:32", "1:12 - 12.32", "23'32 - 23:54"])(
+        "Should know that the military time  is not valid",
+        (timeRange) => {
+          const valid = MilitaryTimeRangeValidator.validate(timeRange);
+          expect(valid).toBeFalsy();
+        }
+      );
     });
 
     describe("Should know if a military time hour or minute is out of range", () => {
-      it("Should know that the time range 27:32 - 12:45 is not valid", () => {
-        const valid = MilitaryTimeRangeValidator.validate("27:32 - 12:54");
-        expect(valid).toBeFalsy();
-      });
-      it("Should know that the time range 22:123 - 12:45 is not valid", () => {
-        const valid = MilitaryTimeRangeValidator.validate("22:123 - 12:54");
-        expect(valid).toBeFalsy();
-      });
-      it("Should know that the time range 22.23:12 - 12:45 is not valid", () => {
-        const valid = MilitaryTimeRangeValidator.validate("22.23:12 - 12:54");
-        expect(valid).toBeFalsy();
-      });
-      it("Should know that the time range 22:12.11 - 12:45 is not valid", () => {
-        const valid = MilitaryTimeRangeValidator.validate("22:12.11 - 12:54");
-        expect(valid).toBeFalsy();
-      });
-      it("Should know that the time range 2I:12 - 12:45 is not valid", () => {
-        const valid = MilitaryTimeRangeValidator.validate("2I:12 - 12:54");
-        expect(valid).toBeFalsy();
-      });
-      it("Should know that the time range 20:2P - 12:45 is not valid", () => {
-        const valid = MilitaryTimeRangeValidator.validate("20:2P - 12:54");
+      it.each([
+        "27:32 - 12:45",
+        "22:123 - 12:45",
+        "2I:12 - 12:45",
+        "22:12.11 - 12:45",
+        "22.23:12 - 12:45",
+        "20:2P - 12:54",
+      ])("Should know that the time range %s is not valid", (timeRange) => {
+        const valid = MilitaryTimeRangeValidator.validate(timeRange);
         expect(valid).toBeFalsy();
       });
     });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -1,58 +1,60 @@
-import { MilitaryTimeValidator } from "./index";
+import { MilitaryTimeRangeValidator } from "./index";
 
 describe("military time validator", () => {
   describe("Should know if a time range is correct", () => {
     it("Should know that the time range 12:33 - 15:52 is valid", () => {
-      const valid = MilitaryTimeValidator.validate("12:33 - 15:52");
+      const valid = MilitaryTimeRangeValidator.validate("12:33 - 15:52");
       expect(valid).toBeTruthy();
     });
 
     describe("Should know if a time range have incorrect format", () => {
       it("Should know that the time range 1:12-12:32 is not valid", () => {
-        const valid = MilitaryTimeValidator.validate("1:12-12:32");
+        const valid = MilitaryTimeRangeValidator.validate("1:12-12:32");
         expect(valid).toBeFalsy();
       });
 
       it("Should know that the time range 1:12 - 12:32 - 14:44 is not valid", () => {
-        const valid = MilitaryTimeValidator.validate("1:12 - 12:32 - 14:44");
+        const valid = MilitaryTimeRangeValidator.validate(
+          "1:12 - 12:32 - 14:44"
+        );
         expect(valid).toBeFalsy();
       });
     });
 
     describe("Should know if a military time have incorrect format", () => {
       it("Should know that the military time 1.12 - 12:32 is not valid", () => {
-        const valid = MilitaryTimeValidator.validate("1.12 - 12:32");
+        const valid = MilitaryTimeRangeValidator.validate("1.12 - 12:32");
         expect(valid).toBeFalsy();
       });
       it("Should know that the military time 1:12 - 12.32 is not valid", () => {
-        const valid = MilitaryTimeValidator.validate("1:12 - 12.32");
+        const valid = MilitaryTimeRangeValidator.validate("1:12 - 12.32");
         expect(valid).toBeFalsy();
       });
     });
 
     describe("Should know if a military time hour or minute is out of range", () => {
       it("Should know that the time range 27:32 - 12:45 is not valid", () => {
-        const valid = MilitaryTimeValidator.validate("27:32 - 12:54");
+        const valid = MilitaryTimeRangeValidator.validate("27:32 - 12:54");
         expect(valid).toBeFalsy();
       });
       it("Should know that the time range 22:123 - 12:45 is not valid", () => {
-        const valid = MilitaryTimeValidator.validate("22:123 - 12:54");
+        const valid = MilitaryTimeRangeValidator.validate("22:123 - 12:54");
         expect(valid).toBeFalsy();
       });
       it("Should know that the time range 22.23:12 - 12:45 is not valid", () => {
-        const valid = MilitaryTimeValidator.validate("22.23:12 - 12:54");
+        const valid = MilitaryTimeRangeValidator.validate("22.23:12 - 12:54");
         expect(valid).toBeFalsy();
       });
       it("Should know that the time range 22:12.11 - 12:45 is not valid", () => {
-        const valid = MilitaryTimeValidator.validate("22:12.11 - 12:54");
+        const valid = MilitaryTimeRangeValidator.validate("22:12.11 - 12:54");
         expect(valid).toBeFalsy();
       });
       it("Should know that the time range 2I:12 - 12:45 is not valid", () => {
-        const valid = MilitaryTimeValidator.validate("2I:12 - 12:54");
+        const valid = MilitaryTimeRangeValidator.validate("2I:12 - 12:54");
         expect(valid).toBeFalsy();
       });
       it("Should know that the time range 20:2P - 12:45 is not valid", () => {
-        const valid = MilitaryTimeValidator.validate("20:2P - 12:54");
+        const valid = MilitaryTimeRangeValidator.validate("20:2P - 12:54");
         expect(valid).toBeFalsy();
       });
     });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -1,5 +1,10 @@
+import { MilitaryTimeValidator } from "./index";
 
-describe('military time validator', () => {
-
-
-})
+describe("military time validator", () => {
+  describe("Should know if a time range is correct", () => {
+    it("Should know that the time range 12:33 - 15:52 is valid", () => {
+      const valid = MilitaryTimeValidator.validate("12:33 - 15:52");
+      expect(valid).toBeTruthy();
+    });
+  });
+});

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -47,6 +47,10 @@ describe("military time validator", () => {
         const valid = MilitaryTimeValidator.validate("22:12.11 - 12:54");
         expect(valid).toBeFalsy();
       });
+      it("Should know that the time range 2I:12 - 12:45 is not valid", () => {
+        const valid = MilitaryTimeValidator.validate("2I:12 - 12:54");
+        expect(valid).toBeFalsy();
+      });
     });
   });
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -29,5 +29,12 @@ describe("military time validator", () => {
         expect(valid).toBeFalsy();
       });
     });
+
+    describe("Should know if a military time hour or minute is out of range", () => {
+      it("Should know that the time range 27:32 - 12:45 is not valid", () => {
+        const valid = MilitaryTimeValidator.validate("27:32 - 12:54");
+        expect(valid).toBeFalsy();
+      });
+    });
   });
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.spec.ts
@@ -2,13 +2,17 @@ import { MilitaryTimeRangeValidator } from "./index";
 
 describe("military time validator", () => {
   describe("Should know if a time range is correct", () => {
-    it.each(["12:33 - 15:52", "23:32 - 23:56", "1:22 - 12:33", "00:33 - 9:22"])(
-      "Should know that the time range %s is valid",
-      (timeRange) => {
-        const valid = MilitaryTimeRangeValidator.validate(timeRange);
-        expect(valid).toBeTruthy();
-      }
-    );
+    it.each([
+      "12:33 - 15:52",
+      "23:32 - 23:56",
+      "1:22 - 12:33",
+      "00:33 - 9:22",
+      "01:12 - 14:32",
+      "22:00 - 23:12",
+    ])("Should know that the time range %s is valid", (timeRange) => {
+      const valid = MilitaryTimeRangeValidator.validate(timeRange);
+      expect(valid).toBeTruthy();
+    });
 
     describe("Should know if a time range have incorrect format", () => {
       it.each(["1:12-12:32", "1:12 - 12:33 - 14:44", "22:33 ~ 23:10"])(
@@ -38,6 +42,7 @@ describe("military time validator", () => {
         "22:12.11 - 12:45",
         "22.23:12 - 12:45",
         "20:2P - 12:54",
+        "25:00 - 12:23",
       ])("Should know that the time range %s is not valid", (timeRange) => {
         const valid = MilitaryTimeRangeValidator.validate(timeRange);
         expect(valid).toBeFalsy();

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -1,3 +1,5 @@
-### Responsabilities:
-
-
+export class MilitaryTimeValidator {
+  static validate(time: string): boolean {
+    return true;
+  }
+}

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -6,13 +6,14 @@ export class MilitaryTimeValidator {
 
     const [hour, minutes] = parsedMilitaryTime;
 
+    if (/[^0-9]/.test(hour)) return false;
+
     const parsedHour = Number.parseFloat(hour);
     const parsedMinutes = Number.parseFloat(minutes);
 
     return (
       parsedHour <= 24 &&
       parsedHour >= 0 &&
-      parsedHour % 1 === 0 &&
       parsedMinutes <= 59 &&
       parsedMinutes >= 0 &&
       parsedMinutes % 1 === 0

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -1,0 +1,3 @@
+### Responsabilities:
+
+

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -4,9 +4,12 @@ export class MilitaryTimeValidator {
 
     if (parsedTimeRange.length !== 2) return false;
 
-    const [startTime] = parsedTimeRange;
+    const [startTime, endTime] = parsedTimeRange;
+
+    console.log({ endTime });
 
     if (startTime.split(":").length !== 2) return false;
+    if (endTime.split(":").length !== 2) return false;
 
     return true;
   }

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -1,6 +1,14 @@
 export class MilitaryTimeValidator {
   private static validateMilitaryTime(militaryTime: string): boolean {
-    return militaryTime.split(":").length === 2;
+    const parsedMilitaryTime = militaryTime.split(":");
+
+    if (parsedMilitaryTime.length !== 2) return false;
+
+    const [hour, minutes] = parsedMilitaryTime;
+
+    const parsedHour = Number.parseFloat(hour);
+
+    return parsedHour <= 24 && parsedHour >= 0;
   }
 
   static validate(timeRange: string): boolean {

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -1,6 +1,12 @@
 export class MilitaryTimeValidator {
-  static validate(time: string): boolean {
-    if (time.split(" - ").length !== 2) return false;
+  static validate(timeRange: string): boolean {
+    const parsedTimeRange = timeRange.split(" - ");
+
+    if (parsedTimeRange.length !== 2) return false;
+
+    const [startTime] = parsedTimeRange;
+
+    if (startTime.split(":").length !== 2) return false;
 
     return true;
   }

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -1,5 +1,7 @@
 export class MilitaryTimeValidator {
   static validate(time: string): boolean {
+    if (time.indexOf(" - ") === -1) return false;
+
     return true;
   }
 }

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -14,7 +14,8 @@ export class MilitaryTimeValidator {
       parsedHour >= 0 &&
       parsedHour % 1 === 0 &&
       parsedMinutes <= 59 &&
-      parsedMinutes >= 0
+      parsedMinutes >= 0 &&
+      parsedMinutes % 1 === 0
     );
   }
 

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -7,8 +7,14 @@ export class MilitaryTimeValidator {
     const [hour, minutes] = parsedMilitaryTime;
 
     const parsedHour = Number.parseFloat(hour);
+    const parsedMinutes = Number.parseFloat(minutes);
 
-    return parsedHour <= 24 && parsedHour >= 0;
+    return (
+      parsedHour <= 24 &&
+      parsedHour >= 0 &&
+      parsedMinutes <= 59 &&
+      parsedMinutes >= 0
+    );
   }
 
   static validate(timeRange: string): boolean {

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -1,4 +1,8 @@
 export class MilitaryTimeValidator {
+  private static validateMilitaryTime(militaryTime: string): boolean {
+    return militaryTime.split(":").length === 2;
+  }
+
   static validate(timeRange: string): boolean {
     const parsedTimeRange = timeRange.split(" - ");
 
@@ -6,11 +10,9 @@ export class MilitaryTimeValidator {
 
     const [startTime, endTime] = parsedTimeRange;
 
-    console.log({ endTime });
+    const validStartTime = this.validateMilitaryTime(startTime);
+    const validEndTime = this.validateMilitaryTime(endTime);
 
-    if (startTime.split(":").length !== 2) return false;
-    if (endTime.split(":").length !== 2) return false;
-
-    return true;
+    return validStartTime && validEndTime;
   }
 }

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -1,35 +1,74 @@
-export class MilitaryTimeValidator {
-  private static validateMilitaryTime(militaryTime: string): boolean {
-    const parsedMilitaryTime = militaryTime.split(":");
+type ParsedTimeRangeResult = {
+  startTime: string;
+  endTime: string;
+};
 
-    if (parsedMilitaryTime.length !== 2) return false;
+type ParseMilitaryTimeResult = {
+  hour: string;
+  minutes: string;
+};
 
-    const [hour, minutes] = parsedMilitaryTime;
-
-    if (/[^0-9]/.test(hour)) return false;
-    if (/[^0-9]/.test(minutes)) return false;
-
-    const parsedHour = Number.parseFloat(hour);
-    const parsedMinutes = Number.parseFloat(minutes);
-
-    return (
-      parsedHour <= 24 &&
-      parsedHour >= 0 &&
-      parsedMinutes <= 59 &&
-      parsedMinutes >= 0
-    );
-  }
-
+export class MilitaryTimeRangeValidator {
   static validate(timeRange: string): boolean {
-    const parsedTimeRange = timeRange.split(" - ");
+    const validTimeRange = this.validateTimeRange(timeRange);
 
-    if (parsedTimeRange.length !== 2) return false;
+    if (!validTimeRange) return false;
 
-    const [startTime, endTime] = parsedTimeRange;
+    const { startTime, endTime } = this.parseTimeRange(timeRange);
 
     const validStartTime = this.validateMilitaryTime(startTime);
     const validEndTime = this.validateMilitaryTime(endTime);
 
-    return validStartTime && validEndTime;
+    if (!validStartTime || !validEndTime) return false;
+
+    return true;
+  }
+
+  private static validateTimeRange(timeRange: string): boolean {
+    return timeRange.split(" - ").length === 2;
+  }
+
+  private static parseTimeRange(timeRange: string): ParsedTimeRangeResult {
+    const [startTime, endTime] = timeRange.split(" - ");
+
+    return { startTime, endTime };
+  }
+
+  private static validateMilitaryTime(militaryTime: string): boolean {
+    const validMilitaryTime = this.validateMilitaryTimeFormat(militaryTime);
+
+    if (!validMilitaryTime) return false;
+
+    const { hour, minutes } = this.parseMilitaryTime(militaryTime);
+
+    const validHour = this.validateHour(hour);
+    const validMinutes = this.validateMinutes(minutes);
+
+    return validHour && validMinutes;
+  }
+
+  private static parseMilitaryTime(
+    militaryTime: string
+  ): ParseMilitaryTimeResult {
+    const [hour, minutes] = militaryTime.split(":");
+    return { hour, minutes };
+  }
+
+  private static validateMilitaryTimeFormat(militaryTime: string): boolean {
+    return militaryTime.length !== 2;
+  }
+
+  private static validateHour(hour: string): boolean {
+    if (/[^0-9]/.test(hour)) return false;
+
+    const parsedHour = Number.parseInt(hour);
+
+    return parsedHour <= 24 && parsedHour >= 0;
+  }
+
+  private static validateMinutes(minutes: string): boolean {
+    if (/[^0-9]/.test(minutes)) return false;
+    const parsedMinutes = Number.parseInt(minutes);
+    return parsedMinutes <= 59 && parsedMinutes >= 0;
   }
 }

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -7,6 +7,7 @@ export class MilitaryTimeValidator {
     const [hour, minutes] = parsedMilitaryTime;
 
     if (/[^0-9]/.test(hour)) return false;
+    if (/[^0-9]/.test(minutes)) return false;
 
     const parsedHour = Number.parseFloat(hour);
     const parsedMinutes = Number.parseFloat(minutes);
@@ -15,8 +16,7 @@ export class MilitaryTimeValidator {
       parsedHour <= 24 &&
       parsedHour >= 0 &&
       parsedMinutes <= 59 &&
-      parsedMinutes >= 0 &&
-      parsedMinutes % 1 === 0
+      parsedMinutes >= 0
     );
   }
 

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -8,13 +8,26 @@ type ParseMilitaryTimeResult = {
   minutes: string;
 };
 
+class MilitaryTimeParser {
+  static parseTimeRange(timeRange: string): ParsedTimeRangeResult {
+    const [startTime, endTime] = timeRange.split(" - ");
+
+    return { startTime, endTime };
+  }
+
+  static parseMilitaryTime(militaryTime: string): ParseMilitaryTimeResult {
+    const [hour, minutes] = militaryTime.split(":");
+    return { hour, minutes };
+  }
+}
+
 export class MilitaryTimeRangeValidator {
   static validate(timeRange: string): boolean {
     const validTimeRange = this.validateTimeRange(timeRange);
 
     if (!validTimeRange) return false;
 
-    const { startTime, endTime } = this.parseTimeRange(timeRange);
+    const { startTime, endTime } = MilitaryTimeParser.parseTimeRange(timeRange);
 
     const validStartTime = this.validateMilitaryTime(startTime);
     const validEndTime = this.validateMilitaryTime(endTime);
@@ -28,18 +41,13 @@ export class MilitaryTimeRangeValidator {
     return timeRange.split(" - ").length === 2;
   }
 
-  private static parseTimeRange(timeRange: string): ParsedTimeRangeResult {
-    const [startTime, endTime] = timeRange.split(" - ");
-
-    return { startTime, endTime };
-  }
-
   private static validateMilitaryTime(militaryTime: string): boolean {
-    const validMilitaryTime = this.validateMilitaryTimeFormat(militaryTime);
+    const validMilitaryTime = militaryTime.length !== 2;
 
     if (!validMilitaryTime) return false;
 
-    const { hour, minutes } = this.parseMilitaryTime(militaryTime);
+    const { hour, minutes } =
+      MilitaryTimeParser.parseMilitaryTime(militaryTime);
 
     const validHour = this.validateHour(hour);
     const validMinutes = this.validateMinutes(minutes);
@@ -47,22 +55,9 @@ export class MilitaryTimeRangeValidator {
     return validHour && validMinutes;
   }
 
-  private static parseMilitaryTime(
-    militaryTime: string
-  ): ParseMilitaryTimeResult {
-    const [hour, minutes] = militaryTime.split(":");
-    return { hour, minutes };
-  }
-
-  private static validateMilitaryTimeFormat(militaryTime: string): boolean {
-    return militaryTime.length !== 2;
-  }
-
   private static validateHour(hour: string): boolean {
     if (/[^0-9]/.test(hour)) return false;
-
     const parsedHour = Number.parseInt(hour);
-
     return parsedHour <= 24 && parsedHour >= 0;
   }
 

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -1,6 +1,6 @@
 export class MilitaryTimeValidator {
   static validate(time: string): boolean {
-    if (time.indexOf(" - ") === -1) return false;
+    if (time.split(" - ").length !== 2) return false;
 
     return true;
   }

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/3_Manage_Complexity/3_1_Military_Time_Validator/src/index.ts
@@ -12,6 +12,7 @@ export class MilitaryTimeValidator {
     return (
       parsedHour <= 24 &&
       parsedHour >= 0 &&
+      parsedHour % 1 === 0 &&
       parsedMinutes <= 59 &&
       parsedMinutes >= 0
     );


### PR DESCRIPTION
- [x] I have tests that validate the following statements 
"01:12 - 14:32" (yes)
"25:00 - 12:23" (no)
"22:00 - 23:12" (yes)
(optionally) confirmed/verified this for more tests
- [x] I have Programmed By Wishful Thinking, designing the response API before it was actually created 
- [x] I have Worked Backwards, starting at the Assert, then going to the Act and the Arrange
- [x] Once I have made the aforementioned tests pass, I have refactored my test specifications to use it.each() to perform parameterization if there is sufficient duplication ([see Tip #3 here](https://www.essentialist.dev/products/the-software-essentialist/categories/2152752280/posts/2166919573))
- [x] There is no duplication in my test code or my production code
- [x] I have attempted to implement the simplest possible Transformations according to the Transformation Priority Premise table.